### PR TITLE
Fix final GEH percentage selection in turn-flow calibration

### DIFF
--- a/realtwin/func_lib/_f_calibration/algo_sumo/cali_turn_inflow.py
+++ b/realtwin/func_lib/_f_calibration/algo_sumo/cali_turn_inflow.py
@@ -119,9 +119,12 @@ def fitness_func_turn_flow(solution: list | np.ndarray, scenario_config: dict = 
                                                            sim_end_time)
     print(f"  GEH: {mean_GEH}, Percentage of GEH<5: {GEH_percent*100:.2f}%")
 
-    # minimize the negative percentage of GEH and the mean GEH
-    # return [mean_GEH, -GEH_percent]
-    return [mean_GEH]
+    # The calibration acceptance criterion is the share of links below the
+    # configured GEH threshold.  Optimizing the mean GEH can select a solution
+    # with a worse accepted-link share, so make the percentage the objective.
+    # Mealpy minimizes this value; the complement converts maximization of the
+    # percentage into a minimization problem without changing its scale.
+    return 1 - GEH_percent
 
 
 class TurnInflowCali:

--- a/tests/test_func_calibration/test_cali_turn_inflow.py
+++ b/tests/test_func_calibration/test_cali_turn_inflow.py
@@ -1,0 +1,72 @@
+##############################################################################
+# Copyright (c) 2024-, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of RealTwin and is distributed under a GPL               #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# Contributors: ORNL Real-Twin Team                                          #
+# Contact: realtwin@ornl.gov                                                 #
+##############################################################################
+
+"""Tests for SUMO turn and inflow calibration."""
+
+import socket
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+# pyufunc resolves the local hostname during import. Some isolated test
+# environments do not publish that hostname in DNS, so keep the import
+# deterministic without changing application behavior.
+with patch.object(socket, "gethostbyname", return_value="127.0.0.1"):
+    from realtwin.func_lib._f_calibration.algo_sumo.cali_turn_inflow import fitness_func_turn_flow
+
+
+@pytest.mark.parametrize(
+    ("geh_percent", "expected_objective"),
+    [
+        (0.0, 1.0),
+        (0.6842, 0.3158),
+        (0.75, 0.25),
+        (1.0, 0.0),
+    ],
+)
+def test_fitness_prioritizes_geh_percentage(tmp_path, geh_percent, expected_objective):
+    """A higher accepted-link percentage must always produce a better fitness."""
+    scenario_config = {
+        "TurnDf_Calibration": object(),
+        "TurnToCalibrate": object(),
+        "InflowDf_Calibration": object(),
+        "InflowEdgeToCalibrate": object(),
+        "RealSummary_Calibration": object(),
+        "network_name": "test-network",
+        "sim_start_time": 0,
+        "sim_end_time": 3600,
+        "path_net": "test-network.net.xml",
+        "dir_turn_inflow": str(tmp_path),
+        "sim_name": "test-network.sumocfg",
+        "calibration_target": {"GEH": 5, "GEHPercent": 0.85},
+    }
+
+    with (
+        patch(
+            "realtwin.func_lib._f_calibration.algo_sumo.cali_turn_inflow.update_turn_flow_from_solution",
+            return_value=(object(), object()),
+        ),
+        patch(
+            "realtwin.func_lib._f_calibration.algo_sumo.cali_turn_inflow.run_jtrrouter_to_create_rou_xml"
+        ),
+        patch(
+            "realtwin.func_lib._f_calibration.algo_sumo.cali_turn_inflow.run_SUMO_create_EdgeData"
+        ),
+        patch(
+            "realtwin.func_lib._f_calibration.algo_sumo.cali_turn_inflow.result_analysis_on_EdgeData",
+            return_value=(0, 4.0, geh_percent),
+        ),
+    ):
+        objective = fitness_func_turn_flow(np.array([0.5]), scenario_config)
+
+    assert objective == pytest.approx(expected_objective)


### PR DESCRIPTION
## Summary

- optimize the accepted-link GEH percentage instead of mean GEH alone
- express percentage maximization as 1 - GEH_percent for Mealpy minimization
- add regression coverage for 0%, 68.42%, 75%, and 100% accepted-link shares

## Why

Issue #44 shows that the final rerun can report 68.42% even when a candidate above 75% was evaluated. The existing objective returns only mean GEH, so the optimizer can prefer a lower mean while discarding a better share of links below the configured GEH threshold. The final rerun then correctly evaluates the selected solution, but it is the wrong solution for the reported acceptance criterion.

## Validation

- python -m pytest -q tests/test_func_calibration/test_cali_turn_inflow.py — 4 passed
- full suite with the existing pyufunc hostname lookup isolated — 157 passed; 2 unrelated environment-dependent failures because SUMO and Windows sumo.exe are not installed on the macOS test host
- the regression test mocks simulator/file generation while exercising the real fitness function and result-to-objective conversion

No real SUMO binary was available for an end-to-end traffic simulation run.

Closes #44

AI disclosure: This change was implemented with assistance from OpenAI Codex. I reviewed the diff and ran the validation described above.